### PR TITLE
feat: base36 support at cid.ipfs.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
     </div>
     <div class='pt4'>
       <label class='dib'>
-        <a class='db pb1 w-100 fw2 tracked ttu f6 teal-muted hover-aqua link' href="https://github.com/ipfs/go-ipfs/issues/4143">
+        <a class='db pb1 w-100 fw2 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway">
           Base32 CIDv1
         </a>
       </label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1160,6 +1160,14 @@
         }
       }
     },
+    "base-x": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -1460,13 +1468,12 @@
       }
     },
     "cids": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.1.tgz",
-      "integrity": "sha512-bs9hGUYHzsclGSt4ipi6SRUBIWYpuEHhd2uPc5hUatNQl6y5mFr+6JvJtN3fGUiNZNohc7rkY6OpXamwj6PQeg==",
+      "version": "https://github.com/ipld/js-cid/tarball/ea5a7f21c0d7c5d692577924a22b9deb86815de3/js-cid.tar.gz",
+      "integrity": "sha512-vCI1PfL2FUlJUSywMu/N0Gbe293029ZzzKniEygAJTz7KEuQwHgabrAuhkeSzs1TUPabZN9r4jGvF7y7kIv17A==",
       "requires": {
         "buffer": "^5.5.0",
         "class-is": "^1.1.0",
-        "multibase": "~0.7.0",
+        "multibase": "^1.0.0",
         "multicodec": "^1.0.1",
         "multihashes": "~0.4.17"
       },
@@ -1478,16 +1485,6 @@
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
-          "integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
           }
         }
       }
@@ -4198,22 +4195,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multibase": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-      "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.0.tgz",
+      "integrity": "sha512-J/sf1Pr98nodBEnf8QMyd+gAe3or+9oL6x3hIWpu2d9WbEOA7ot7CU0NPWy5jGoOOIiK0Ej9u4FSOwrBfhNmIA==",
       "requires": {
         "base-x": "^3.0.8",
         "buffer": "^5.5.0"
       },
       "dependencies": {
-        "base-x": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-          "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
         "buffer": {
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
@@ -4262,6 +4251,15 @@
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1468,14 +1468,15 @@
       }
     },
     "cids": {
-      "version": "https://github.com/ipld/js-cid/tarball/ea5a7f21c0d7c5d692577924a22b9deb86815de3/js-cid.tar.gz",
-      "integrity": "sha512-vCI1PfL2FUlJUSywMu/N0Gbe293029ZzzKniEygAJTz7KEuQwHgabrAuhkeSzs1TUPabZN9r4jGvF7y7kIv17A==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.2.tgz",
+      "integrity": "sha512-2tEASn0yDUPkXPUjXm3UslYyt4KWh8lQLaR5Yh68w55a5nZgFYzO2LK44c79228XL4UWMb4Wa4jQO4/8s2xLSg==",
       "requires": {
-        "buffer": "^5.5.0",
+        "buffer": "^5.6.0",
         "class-is": "^1.1.0",
         "multibase": "^1.0.0",
         "multicodec": "^1.0.1",
-        "multihashes": "~0.4.17"
+        "multihashes": "~0.4.19"
       },
       "dependencies": {
         "buffer": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Victor Bjelkholm",
   "license": "MIT",
   "dependencies": {
-    "cids": "https://github.com/ipld/js-cid/tarball/ea5a7f21c0d7c5d692577924a22b9deb86815de3/js-cid.tar.gz",
+    "cids": "~0.8.2",
     "ipfs-css": "^1.1.0",
     "multibase": "^1.0.0",
     "multicodec": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "author": "Victor Bjelkholm",
   "license": "MIT",
   "dependencies": {
-    "cids": "^0.8.1",
+    "cids": "https://github.com/ipld/js-cid/tarball/ea5a7f21c0d7c5d692577924a22b9deb86815de3/js-cid.tar.gz",
     "ipfs-css": "^1.1.0",
-    "multibase": "^0.7.0",
+    "multibase": "^1.0.0",
     "multicodec": "^1.0.1",
     "multihashes": "^0.4.19",
     "parcel-bundler": "^1.12.4",


### PR DESCRIPTION
> Part of https://github.com/ipfs/go-ipfs/issues/7318

This PR:

- adds support for Base36 and closes #23 
- fixes CIDv1 link to point at docs

Needs a new release of js-cid before this can be merged.

