### PR TITLE
feat: add favicon and header link to GitHub repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,23 +31,23 @@
     <div class='pt2 measure-wide cf pr2 pr0-l'>
       <a class='gray hover-aqua link underline fr ml3' href="https://proto.school/#/anatomy-of-a-cid">Tutorial</a>
       <a class='gray hover-aqua link underline fr' href="https://github.com/ipld/cid">Spec</a>
-      <label for="input-cid" class='db pb2 w-100 fw2 tracked ttu f5 teal'>CID</label>
+      <label for="input-cid" class='db pb2 w-100 tracked ttu f5 teal'>CID</label>
       <input id="input-cid" type="text" class='db w-100 ph1 pv2 monospace input-reset ba b--black-20 border-box' />
     </div>
     <small id="input-error" class="db yellow f6 pt1 overflow-x-auto" style="opacity: 0; min-height:20px;"></small>
     <div class='pt3'>
       <label class='db'>
-        <a class='fw2 tracked ttu f5 teal-muted hover-aqua link' href='https://github.com/ipld/cid#human-readable-cids'>
+        <a class='tracked ttu f5 teal-muted hover-aqua link' href='https://github.com/ipld/cid#human-readable-cids'>
           Human readable CID
         </a>
       </label>
       <pre class='f5 sans-serif fw5 ma0 pv2 dib overflow-x-auto w-100' id="hr-cid"></pre>
-      <div class='f5 sans-serif fw2 ma0 gray ttu f7 tracked'>multibase - version -  multicodec - multihash</div>
+      <div class='f5 sans-serif ma0 gray ttu f7 tracked'>multibase - version -  multicodec - multihash</div>
       <div class='dn' id="cid" ></div>
     </div>
     <div class='pt4'>
       <label class='db'>
-        <a class='pb1 w-100 fw2 tracked ttu f6 teal-muted hover-aqua link' href="https://github.com/multiformats/multibase">
+        <a class='pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://github.com/multiformats/multibase">
           Multibase
         </a>
       </label>
@@ -55,7 +55,7 @@
     </div>
     <div class='pt4'>
       <label clas='db'>
-        <a class='pb1 w-100 fw2 tracked ttu f6 teal-muted hover-aqua link' href="https://github.com/multiformats/multicodec">
+        <a class='pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://github.com/multiformats/multicodec">
           Multicodec
         </a>
       </label>
@@ -63,7 +63,7 @@
     </div>
     <div class='pt4'>
       <label class='dib'>
-        <a class='db pb1 w-100 fw2 tracked ttu f6 teal-muted hover-aqua link' href="https://github.com/multiformats/multihash">
+        <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://github.com/multiformats/multihash">
           Multihash
         </a>
       </label>
@@ -71,7 +71,7 @@
     </div>
     <div class='pt4'>
       <label class='dib'>
-        <a class='db pb1 w-100 fw2 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway">
+        <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway">
           Base32 CIDv1
         </a>
       </label>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>CID: Content-address Identifiers</title>
+  <title>CID Inspector | IPFS</title>
   <meta name="description" content="Convert IPFS CIDs into human-readable from">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="stylesheet" href="./main.css">
+  <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlo89/56ZQ/8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACUjDu1lo89/6mhTP+zrVP/nplD/5+aRK8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHNiIS6Wjz3/ubFY/761W/+vp1D/urRZ/8vDZf/GvmH/nplD/1BNIm8AAAAAAAAAAAAAAAAAAAAAAAAAAJaPPf+knEj/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf+tpk7/nplD/wAAAAAAAAAAAAAAAJaPPf+2rVX/vrVb/761W/++tVv/vrVb/6+nUP+6tFn/y8Nl/8vDZf/Lw2X/y8Nl/8G6Xv+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/761W/+vp1D/urRZ/8vDZf/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf++tVv/vrVb/761W/++tVv/vbRa/5aPPf+emUP/y8Nl/8vDZf/Lw2X/y8Nl/8vDZf+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/5qTQP+inkb/op5G/6KdRv/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/sqlS/56ZQ//LxWb/0Mlp/9DJaf/Kw2X/oJtE/7+3XP/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf+9tFr/mJE+/7GsUv/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+xrFL/nplD/8vDZf+emUP/AAAAAAAAAACWjz3/op5G/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+inkb/nplD/wAAAAAAAAAAAAAAAKKeRv+3slb/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+1sFX/op5G/wAAAAAAAAAAAAAAAAAAAAAAAAAAop5GUKKeRv/Nxmf/0cpq/9HKav/Rymr/0cpq/83GZ/+inkb/op5GSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G16KeRv/LxWb/y8Vm/6KeRv+inkaPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G/6KeRtcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/n8AAPgfAADwDwAAwAMAAIABAACAAQAAgAEAAIABAACAAQAAgAEAAIABAACAAQAAwAMAAPAPAAD4HwAA/n8AAA==" />
 </head>
 <body class='sans-serif bg-white'>
   <header class='pv3 ph2 ph3-l bg-navy cf'>

--- a/index.html
+++ b/index.html
@@ -10,12 +10,23 @@
   <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlo89/56ZQ/8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACUjDu1lo89/6mhTP+zrVP/nplD/5+aRK8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHNiIS6Wjz3/ubFY/761W/+vp1D/urRZ/8vDZf/GvmH/nplD/1BNIm8AAAAAAAAAAAAAAAAAAAAAAAAAAJaPPf+knEj/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf+tpk7/nplD/wAAAAAAAAAAAAAAAJaPPf+2rVX/vrVb/761W/++tVv/vrVb/6+nUP+6tFn/y8Nl/8vDZf/Lw2X/y8Nl/8G6Xv+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/761W/+vp1D/urRZ/8vDZf/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf++tVv/vrVb/761W/++tVv/vbRa/5aPPf+emUP/y8Nl/8vDZf/Lw2X/y8Nl/8vDZf+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/5qTQP+inkb/op5G/6KdRv/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/sqlS/56ZQ//LxWb/0Mlp/9DJaf/Kw2X/oJtE/7+3XP/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf+9tFr/mJE+/7GsUv/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+xrFL/nplD/8vDZf+emUP/AAAAAAAAAACWjz3/op5G/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+inkb/nplD/wAAAAAAAAAAAAAAAKKeRv+3slb/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+1sFX/op5G/wAAAAAAAAAAAAAAAAAAAAAAAAAAop5GUKKeRv/Nxmf/0cpq/9HKav/Rymr/0cpq/83GZ/+inkb/op5GSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G16KeRv/LxWb/y8Vm/6KeRv+inkaPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G/6KeRtcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/n8AAPgfAADwDwAAwAMAAIABAACAAQAAgAEAAIABAACAAQAAgAEAAIABAACAAQAAwAMAAPAPAAD4HwAA/n8AAA==" />
 </head>
 <body class='sans-serif bg-white'>
-  <header class='pv3 ph2 ph3-l bg-navy cf'>
-    <a href="https://ipfs.io/" title='ipfs.io'>
-      <img src="https://ipfs.io/images/ipfs-logo.svg" class='v-mid' style='height:50px' />
-    </a>
-    <h1 class='aqua fw2 montserrat dib ma0 pv2 ph1 v-mid fr f3 lh-copy'>CID inspector</h1>
-  </header>
+  <header class="flex-ns items-center pt3 pb2 ph3 bg-navy bb bw3 border-aqua tc justify-between">
+    <div>
+      <a href="https://ipfs.io/" title="Visit ipfs.io">
+        <img src="https://ipfs.io/images/ipfs-logo.svg" style='height:50px' />
+      </a>
+    </div>
+  <div class='pb1 ma0 inline-flex items-center'>
+    <h1 class='f3 fw2 montserrat aqua ttu'>CID Inspector</h1>
+    <div class='pl3'>
+      <a href="https://github.com/multiformats/cid-utils-website" target="_blank" rel="noopener noreferrer" aria-label="View source on GitHub">
+        <svg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 32.58 31.77'>
+          <path fill='#7f8491' d='M16.29 0a16.29 16.29 0 00-5.15 31.75c.82.15 1.11-.36 1.11-.79v-2.77C7.7 29.18 6.74 26 6.74 26a4.36 4.36 0 00-1.81-2.39c-1.47-1 .12-1 .12-1a3.43 3.43 0 012.49 1.68 3.48 3.48 0 004.74 1.36 3.46 3.46 0 011-2.18c-3.62-.41-7.42-1.81-7.42-8a6.3 6.3 0 011.67-4.37 5.94 5.94 0 01.16-4.31s1.37-.44 4.48 1.67a15.41 15.41 0 018.16 0c3.11-2.11 4.47-1.67 4.47-1.67a5.91 5.91 0 01.2 4.28 6.3 6.3 0 011.67 4.37c0 6.26-3.81 7.63-7.44 8a3.85 3.85 0 011.11 3v4.47c0 .53.29.94 1.12.78A16.29 16.29 0 0016.29 0z'/>
+        </svg>
+      </a>
+    </div>
+  </div>
+</header>
   <section class='pv4 pl2 pl5-l'>
     <div class='pt2 measure-wide cf pr2 pr0-l'>
       <a class='gray hover-aqua link underline fr ml3' href="https://proto.school/#/anatomy-of-a-cid">Tutorial</a>


### PR DESCRIPTION
- Adds inline favicon to CID inspector site
- Adds GitHub logo in header (matches prior art in [IPLD Explorer](https://explore.ipld.io/) and [public gateway checker](https://ipfs.github.io/public-gateway-checker/)
- Brings up weight of header type for legibility/accessibility
- Changes tab title to "CID Inspector | IPFS" for clarity

![image](https://user-images.githubusercontent.com/1507828/88087897-ddf21300-cb46-11ea-85a3-be563fbda035.png)

Closes #27 
Closes #28