### PR TITLE
feat: provide cidv1 in base36 when needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,11 +71,19 @@
     </div>
     <div class='pt4'>
       <label class='dib'>
-        <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway">
-          Base32 CIDv1
+        <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.io/concepts/content-addressing/#version-1-v1">
+          CIDv1 (Base32)
         </a>
       </label>
-      <div class='f5 sans-serif ma0 fw4 pt2'id="base32cidv1"></div>
+      <div class='f5 monospace ma0 fw4 pt2' id="base32cidv1"></div>
+    </div>
+    <div class='pt4' id='dns'>
+      <label class='dib'>
+        <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway">
+          CIDv1 (Base36, optimized for Subdomains)
+        </a>
+      </label>
+      <div class='f5 monospace ma0 fw4 pt2' id="dnscidv1"></div>
     </div>
   </section>
   <footer class='mt2 pv2 ph2 ph3-l bt b--light-gray'>


### PR DESCRIPTION
This adds Base36 version  of CIDv1 if it fits inside a single DNS label. 
Follows convention introduced in https://github.com/ipfs/go-ipfs/pull/7441 where we redirect to Base36 only if it helps with DNS limit.

> ![2020-08-26--22-12-53](https://user-images.githubusercontent.com/157609/91351896-50f74500-e7e9-11ea-9fe5-ebca159b05c3.png)


Examples:
- [regular CID, Base32 is enough, Base36 section is hidden](https://bafybeigmo2fidbzsy27pbcwmt2net6p2bli4m54gipmdnjkvtjyd5gue2i.ipfs.dweb.link/#bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi)
- [libp2p-key, Base36 is provided](https://bafybeigmo2fidbzsy27pbcwmt2net6p2bli4m54gipmdnjkvtjyd5gue2i.ipfs.dweb.link/#bafzaajaiaejcat4yhiwnr2qz73mtu6vrnj2krxlpfoa3wo2pllfi37quorgwh2jw)
- [super long CID, DNS label warning is displayed instead of Base36](https://bafybeigmo2fidbzsy27pbcwmt2net6p2bli4m54gipmdnjkvtjyd5gue2i.ipfs.dweb.link/#bafkrgqhhyivzstcz3hhswshfjgy6ertgmnqeleynhwt4dlfsthi4hn7zgh4uvlsb5xncykzapi3ocd4lzogukir6ksdy6wzrnz6ohnv4aglcs)


Q: Is it ok to hide Base36 when it is not really needed? Or maybe should we always show it, to educate users that the same CID  can be encoded  in different bases?

cc @ribasushi @aschmahmann @jessicaschilling 