### PR TITLE
chore: move hosting to Fleek

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,35 +16,8 @@ jobs:
           paths:
             - dist
 
-  deploy:
-    docker:
-      - image: olizilla/ipfs-dns-deploy:latest
-        environment:
-          DOMAIN: cid.ipfs.io
-          BUILD_DIR: dist
-          CLUSTER_HOST: /dnsaddr/ipfs-websites.collab.ipfscluster.io
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Deploy website to IPFS
-          command: |
-            pin_name="$DOMAIN build $CIRCLE_BUILD_NUMBER"
-
-            hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
-
-            echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
-
-            if [ "$CIRCLE_BRANCH" == "master" ] ; then
-              dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
-            fi
-
 workflows:
   version: 2
   build-deploy:
     jobs:
       - build
-      - deploy:
-          context: ipfs-dns-deploy
-          requires:
-            - build


### PR DESCRIPTION
I tried to apply fix from https://github.com/ipfs-shipyard/ipfs-webui/pull/1620 but it still [failed](https://app.circleci.com/pipelines/github/multiformats/cid-utils-website/25/workflows/7740035f-d155-493a-a7d3-76d923e6dd74/jobs/51). 
https://cid.ipfs.io is a small website, so I suggest we move its hosting to Fleek. 

- [x] I've already set up Fleek integration under `cid-utils-website` name and it builds `master` + there is a preview on PRs
- [x] :point_right:  **We need to update  `cid.ipfs.io` in DNS to point at Fleek** 
  > ![details here](https://user-images.githubusercontent.com/157609/93610645-9dd7d100-f9cd-11ea-99a9-d98ce947710a.png)


@mburns are you able to help with updating DNS? 
(would not bother you, but we want to land this before people start playing with go-ipfs 0.7)