### PR TITLE
feat: display byte length of CID

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,14 +72,30 @@
       </label>
       <div class='f5 sans-serif ma0 fw4 pt2'id="multihash"></div>
     </div>
+
+
     <div class='pt4'>
       <label class='dib'>
-        <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.tech/concepts/content-addressing/#version-1-v1">
-          CID length (Bytes)
+        <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link'>
+          CID Byte length
         </a>
       </label>
-      <div class='f5 monospace ma0 overflow-x-auto overflow-y-hidden fw4 pt2' id="cidbytelength"></div>
+
+      <div class='pb1'>
+        <dt class='dib pr2 sans-serif charcoal-muted ttu f7 tracked'>Binary (Bytes)</dt>
+        <dd class='dib ma0 pa0 fw5 overflow-x-auto overflow-y-hidden w-100' id="cidbytelengthbin"></dd>
+      </div>
+      <div class='pb1'>
+        <dt class='dib pr2 sans-serif charcoal-muted ttu f7 tracked'>As base32 string (Bytes)</dt>
+        <dd class='dib ma0 pa0 fw5 overflow-x-auto overflow-y-hidden w-100' id="cidbytelengthbase32"></dd>
+      </div>
+      <div class='pb1'>
+        <dt class='dib pr2 sans-serif charcoal-muted ttu f7 tracked' id="cid-base-label"></dt>
+        <dd class='dib ma0 pa0 fw5 overflow-x-auto overflow-y-hidden w-100' id="cidbytelength-input"></dd>
+      </div>
     </div>
+
+
     <div class='pt4'>
       <label class='dib'>
         <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.tech/concepts/content-addressing/#version-1-v1">

--- a/index.html
+++ b/index.html
@@ -75,6 +75,14 @@
     <div class='pt4'>
       <label class='dib'>
         <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.tech/concepts/content-addressing/#version-1-v1">
+          CID length (Bytes)
+        </a>
+      </label>
+      <div class='f5 monospace ma0 overflow-x-auto overflow-y-hidden fw4 pt2' id="cidbytelength"></div>
+    </div>
+    <div class='pt4'>
+      <label class='dib'>
+        <a class='db pb1 w-100 tracked ttu f6 teal-muted hover-aqua link' href="https://docs.ipfs.tech/concepts/content-addressing/#version-1-v1">
           CIDv1 (Base32)
         </a>
       </label>

--- a/index.html
+++ b/index.html
@@ -81,17 +81,17 @@
         </a>
       </label>
 
-      <div class='pb1'>
-        <dt class='dib pr2 sans-serif charcoal-muted ttu f7 tracked'>Binary (Bytes)</dt>
-        <dd class='dib ma0 pa0 fw5 overflow-x-auto overflow-y-hidden w-100' id="cidbytelengthbin"></dd>
+      <div class='pb1' id="cid-input-byte-length">
+        <dt class='dib pr2 sans-serif charcoal-muted ttu f7 tracked' id="cid-base-label"></dt>
+        <dd class='dib ma0 pa0 fw5 overflow-x-auto overflow-y-hidden w-100' id="cidbytelength-input"></dd>
       </div>
       <div class='pb1'>
         <dt class='dib pr2 sans-serif charcoal-muted ttu f7 tracked'>As base32 string (Bytes)</dt>
         <dd class='dib ma0 pa0 fw5 overflow-x-auto overflow-y-hidden w-100' id="cidbytelengthbase32"></dd>
       </div>
       <div class='pb1'>
-        <dt class='dib pr2 sans-serif charcoal-muted ttu f7 tracked' id="cid-base-label"></dt>
-        <dd class='dib ma0 pa0 fw5 overflow-x-auto overflow-y-hidden w-100' id="cidbytelength-input"></dd>
+        <dt class='dib pr2 sans-serif charcoal-muted ttu f7 tracked'>Binary (Bytes)</dt>
+        <dd class='dib ma0 pa0 fw5 overflow-x-auto overflow-y-hidden w-100' id="cidbytelengthbin"></dd>
       </div>
     </div>
 

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const base32CidV1Output = document.querySelector('#base32cidv1')
   const cidByteLengthBinOutput = document.querySelector('#cidbytelengthbin')
   const cidByteLengthBase32Output = document.querySelector('#cidbytelengthbase32')
+  const inputByteLengthContainer = document.querySelector("#cid-input-byte-length")
   const inputByteLengthLabel = document.querySelector('#cid-base-label')
   const inputByteLength = document.querySelector('#cidbytelength-input')
   const dns = document.querySelector('#dns')
@@ -121,10 +122,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const cidb32 = data.cid.toV1().toString()
       base32CidV1Output.innerHTML = cidb32
-      inputByteLengthLabel.innerHTML = "As " + data.multibase.name + " string (Bytes)"
-      inputByteLength.innerHTML = new Blob([value.trim()]).size
       cidByteLengthBinOutput.innerHTML = data.cid.byteLength
       cidByteLengthBase32Output.innerHTML = new Blob([data.cid.toString()]).size
+
+      // Display the byte length of the input and hide if it's base32 (since it will always show)
+      inputByteLengthContainer.style.display = (data.multibase.name === 'base32') ? 'none' : 'block'
+      inputByteLengthLabel.innerHTML = "As " + data.multibase.name + " string (Bytes)"
+      inputByteLength.innerHTML = new Blob([value.trim()]).size
 
       const dnsPrefix = toDNSPrefix(data.cid)
       dns.style.visibility = cidb32 !== dnsPrefix ? 'visible' : 'hidden'

--- a/index.js
+++ b/index.js
@@ -77,7 +77,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const multicodecOutput = document.querySelector('#multicodec')
   const multibaseOutput = document.querySelector('#multibase')
   const base32CidV1Output = document.querySelector('#base32cidv1')
-  const cidByteLengthOutput = document.querySelector('#cidbytelength')
+  const cidByteLengthBinOutput = document.querySelector('#cidbytelengthbin')
+  const cidByteLengthBase32Output = document.querySelector('#cidbytelengthbase32')
+  const inputByteLengthLabel = document.querySelector('#cid-base-label')
+  const inputByteLength = document.querySelector('#cidbytelength-input')
   const dns = document.querySelector('#dns')
   const dnsCidV1Output = document.querySelector('#dnscidv1')
   const humanReadableCidOutput = document.querySelector('#hr-cid')
@@ -118,7 +121,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const cidb32 = data.cid.toV1().toString()
       base32CidV1Output.innerHTML = cidb32
-      cidByteLengthOutput.innerHTML = data.cid.byteLength
+      inputByteLengthLabel.innerHTML = "As " + data.multibase.name + " string (Bytes)"
+      inputByteLength.innerHTML = new Blob([value.trim()]).size
+      cidByteLengthBinOutput.innerHTML = data.cid.byteLength
+      cidByteLengthBase32Output.innerHTML = new Blob([data.cid.toString()]).size
 
       const dnsPrefix = toDNSPrefix(data.cid)
       dns.style.visibility = cidb32 !== dnsPrefix ? 'visible' : 'hidden'

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const multicodecOutput = document.querySelector('#multicodec')
   const multibaseOutput = document.querySelector('#multibase')
   const base32CidV1Output = document.querySelector('#base32cidv1')
+  const cidByteLengthOutput = document.querySelector('#cidbytelength')
   const dns = document.querySelector('#dns')
   const dnsCidV1Output = document.querySelector('#dnscidv1')
   const humanReadableCidOutput = document.querySelector('#hr-cid')
@@ -117,6 +118,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const cidb32 = data.cid.toV1().toString()
       base32CidV1Output.innerHTML = cidb32
+      cidByteLengthOutput.innerHTML = data.cid.byteLength
 
       const dnsPrefix = toDNSPrefix(data.cid)
       dns.style.visibility = cidb32 !== dnsPrefix ? 'visible' : 'hidden'


### PR DESCRIPTION
It's really useful to know the length of a CID and that it can vary depending on what it represents, e.g. the identity CID holding a private key.


Example: 

<img width="901" alt="Screen Shot 2022-11-28 at 7 13 59 PM" src="https://user-images.githubusercontent.com/1992255/204350580-cd0dcf4d-a033-4fa6-87eb-18fde53b7c47.png">
