### PR TITLE
fix: allow unknown multihashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function decodeCID (value) {
     multicodec: codecs[cid.code],
     multihash: {
       ...cid.multihash,
-      name: codecs[cid.multihash.code].name
+      name: codecs[cid.multihash.code]?.name || 'unknown multihash'
     }
   }
 }


### PR DESCRIPTION
Was getting an error for unknown and private use multihashes

`Cannot read properties of undefined (reading 'name')`

Few test CID's
`bafkycqbsbxeqx5ftzufzjcent3qugoo46n3eettm5kqnkmgf6fgyk2mlok5fx3yfo7uoe74hm6rvyg2us5qotpif`
`bafk77777aezfzdn7wit7polbuydn5lkoqc4dmtiykfvgil6brr5wla2shh4so5q3earlpj53o33dumsxs4lsz5vdlvhq`